### PR TITLE
Add Savitri Network header

### DIFF
--- a/components/Global/SavitriHeader.jsx
+++ b/components/Global/SavitriHeader.jsx
@@ -1,0 +1,38 @@
+const navLinks = [
+  { label: "Home", href: "https://savitrinetwork.com" },
+  { label: "About", href: "https://savitrinetwork.com" },
+  { label: "Ecosystem", href: "https://savitrinetwork.com" },
+  { label: "Docs", href: "https://savitrinetwork.com" },
+  { label: "Blog", href: "https://savitrinetwork.com" },
+];
+
+export default function SavitriHeader() {
+  return (
+    <header className="bg-white shadow">
+      <div className="max-w-7xl mx-auto flex items-center justify-between py-3 px-4">
+        <a
+          href="https://savitrinetwork.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center space-x-2"
+        >
+          <img src="/SavitriNetwork.png" alt="Savitri Network" className="h-8 w-auto" />
+          <span className="font-semibold text-gray-800">Savitri Network</span>
+        </a>
+        <nav className="space-x-6 hidden md:block">
+          {navLinks.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-gray-700 hover:text-teal-600"
+            >
+              {link.label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from "react";
 import Head from "next/head";
 import {
-  Header,
   HeroSection,
   Footer,
   BlockchainFeatures,
@@ -17,6 +16,7 @@ import {
   TestimonialsSlider,
   ReferralPopup,
 } from "../components/HomePage/index";
+import SavitriHeader from "../components/Global/SavitriHeader";
 
 const TOKEN_NAME = process.env.NEXT_PUBLIC_TOKEN_NAME;
 const TOKEN_SYMBOL = process.env.NEXT_PUBLIC_TOKEN_SYMBOL;
@@ -109,7 +109,7 @@ export default function Home() {
         <link rel="icon" href="/Savitri.png" />
       </Head>
 
-      <Header isDarkMode={isDarkMode} toggleDarkMode={toggleDarkMode} />
+      <SavitriHeader />
 
       <main>
         <HeroSection


### PR DESCRIPTION
## Summary
- create `SavitriHeader` component with links to savitrinetwork.com
- use this new header on the home page

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68885f31d9e48322929f9be19f2b53d1