### PR TITLE
Fix active dashboard tab icon visibility

### DIFF
--- a/components/Global/Sidebar.jsx
+++ b/components/Global/Sidebar.jsx
@@ -240,8 +240,10 @@ const Sidebar = ({
               href="#"
               className={`flex items-center gap-3 px-4 py-2.5 rounded-lg ${
                 activeItem === item.name
-                  ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
-                  : `${isDarkMode ? "text-gray-400" : "text-gray-600"} 
+                  ? isDarkMode
+                    ? "text-white"
+                    : "text-gray-900"
+                  : `${isDarkMode ? "text-gray-400" : "text-gray-600"}
                    hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
               }`}
               onClick={(e) => {
@@ -255,8 +257,20 @@ const Sidebar = ({
                 }
               }}
             >
-              <item.icon className="w-5 h-5" />
-              <span>{item.name}</span>
+              <item.icon
+                className={`w-5 h-5 ${
+                  activeItem === item.name ? "text-[#9761F4]" : ""
+                }`}
+              />
+              <span
+                className={`${
+                  activeItem === item.name
+                    ? "bg-clip-text text-transparent text-light-gradient"
+                    : ""
+                }`}
+              >
+                {item.name}
+              </span>
             </Link>
           ))}
         </nav>
@@ -273,8 +287,10 @@ const Sidebar = ({
                 href="#"
                 className={`flex items-center gap-3 px-4 py-2.5 rounded-lg ${
                   activeItem === item.name
-                    ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
-                    : `${isDarkMode ? "text-gray-400" : "text-gray-600"} 
+                    ? isDarkMode
+                      ? "text-white"
+                      : "text-gray-900"
+                    : `${isDarkMode ? "text-gray-400" : "text-gray-600"}
             hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
                 }`}
                 onClick={(e) => {
@@ -288,8 +304,20 @@ const Sidebar = ({
                   }
                 }}
               >
-                <item.icon className="w-5 h-5" />
-                <span>{item.name}</span>
+                <item.icon
+                  className={`w-5 h-5 ${
+                    activeItem === item.name ? "text-[#9761F4]" : ""
+                  }`}
+                />
+                <span
+                  className={`${
+                    activeItem === item.name
+                      ? "bg-clip-text text-transparent text-light-gradient"
+                      : ""
+                  }`}
+                >
+                  {item.name}
+                </span>
               </Link>
             ))}
           </nav>

--- a/components/UserDashboard/UserDashboard.jsx
+++ b/components/UserDashboard/UserDashboard.jsx
@@ -289,14 +289,26 @@ const UserDashboard = ({ isDarkMode }) => {
               onClick={() => setActiveTab(tab.id)}
               className={`flex items-center gap-2 px-4 sm:px-6 py-3 whitespace-nowrap transition-colors ${
                 activeTab === tab.id
-                  ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
+                  ? isDarkMode
+                    ? "text-white"
+                    : "text-gray-900"
                   : isDarkMode
                   ? "text-gray-400 hover:text-gray-300"
                   : "text-gray-600 hover:text-gray-900"
               }`}
             >
-              {tab.icon}
-              <span>{tab.label}</span>
+              <tab.icon
+                className={`w-5 h-5 ${activeTab === tab.id ? "text-[#9761F4]" : ""}`}
+              />
+              <span
+                className={`${
+                  activeTab === tab.id
+                    ? "bg-clip-text text-transparent text-light-gradient"
+                    : ""
+                }`}
+              >
+                {tab.label}
+              </span>
             </button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- ensure active icons remain visible in the dashboard tabs
- adjust sidebar active style so icons keep color while tab text retains gradient

## Testing
- `npm install`
- `npm run build` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688924b97ef88322bd8423d47be1e470