### PR TITLE
Fix sidebar active icon color

### DIFF
--- a/components/Global/Sidebar.jsx
+++ b/components/Global/Sidebar.jsx
@@ -205,7 +205,7 @@ const Sidebar = ({
         } `}
       >
         {" "}
-        <a href="/">
+        <Link href="/">
           <div className="flex items-center gap-2">
             <img
               style={{
@@ -224,7 +224,7 @@ const Sidebar = ({
               {TOKEN_NAME}
             </span>
           </div>{" "}
-        </a>
+        </Link>
       </div>
 
       {/* Navigation Section - Scrollable */}
@@ -240,9 +240,8 @@ const Sidebar = ({
               href="#"
               className={`flex items-center gap-3 px-4 py-2.5 rounded-lg ${
                 activeItem === item.name
-                  ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
-                  : `${isDarkMode ? "text-gray-400" : "text-gray-600"} 
-                   hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
+                  ? "hover:from-teal-500 hover:to-indigo-600"
+                  : `${isDarkMode ? "text-gray-400" : "text-gray-600"} hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
               }`}
               onClick={(e) => {
                 e.preventDefault();
@@ -255,8 +254,8 @@ const Sidebar = ({
                 }
               }}
             >
-              <item.icon className="w-5 h-5" />
-              <span>{item.name}</span>
+              <item.icon className={`w-5 h-5 ${activeItem === item.name ? "text-white" : ""}`} />
+              <span className={activeItem === item.name ? "text-light-gradient" : ""}>{item.name}</span>
             </Link>
           ))}
         </nav>
@@ -273,9 +272,8 @@ const Sidebar = ({
                 href="#"
                 className={`flex items-center gap-3 px-4 py-2.5 rounded-lg ${
                   activeItem === item.name
-                    ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
-                    : `${isDarkMode ? "text-gray-400" : "text-gray-600"} 
-            hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
+                    ? "hover:from-teal-500 hover:to-indigo-600"
+                    : `${isDarkMode ? "text-gray-400" : "text-gray-600"} hover:bg-[#23ADAC] hover:bg-opacity-20 hover:text-[#4D4BE1]`
                 }`}
                 onClick={(e) => {
                   e.preventDefault();
@@ -288,8 +286,8 @@ const Sidebar = ({
                   }
                 }}
               >
-                <item.icon className="w-5 h-5" />
-                <span>{item.name}</span>
+                <item.icon className={`w-5 h-5 ${activeItem === item.name ? "text-white" : ""}`} />
+                <span className={activeItem === item.name ? "text-light-gradient" : ""}>{item.name}</span>
               </Link>
             ))}
           </nav>


### PR DESCRIPTION
## Summary
- keep icons visible by switching active icon color to white
- use gradient text only on navigation item labels
- fix logo link to use Next.js `<Link>`

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688924b97ef88322bd8423d47be1e470