### PR TITLE
Restore colored buttons in header

### DIFF
--- a/components/Global/CustomConnectButton.jsx
+++ b/components/Global/CustomConnectButton.jsx
@@ -32,7 +32,7 @@ const CustomConnectButton = ({ active, childStyle }) => {
                 return (
                   <button
                     onClick={openConnectModal}
-                    className={`flex items-center text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-md transition-colors ${childStyle}`}
+                    className={`flex items-center bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-md transition-colors ${childStyle}`}
                   >
                     <RiWallet3Line className="mr-2" size={20} />
                     CONNECT WALLET
@@ -56,7 +56,7 @@ const CustomConnectButton = ({ active, childStyle }) => {
                   {active && (
                     <button
                       onClick={openChainModal}
-                      className="text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+                      className="bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
                     >
                       {chain.hasIcon && (
                         <div className="w-5 h-5">
@@ -75,7 +75,7 @@ const CustomConnectButton = ({ active, childStyle }) => {
 
                   <button
                     onClick={openAccountModal}
-                    className="text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
+                    className="bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white px-4 py-2 rounded-lg flex items-center gap-2"
                   >
                     {account.displayName}
                     {account.displayBalance && ` (${account.displayBalance})`}

--- a/components/HomePage/Header.jsx
+++ b/components/HomePage/Header.jsx
@@ -485,11 +485,11 @@ const Header = ({ isDarkMode, toggleDarkMode }) => {
           <div className="hidden md:flex items-center space-x-4">
             <button
               onClick={toggleDarkMode}
-              className={`p-2 rounded-full transition-colors duration-300 ${
+              className={`p-2 rounded-full ${
                 isDarkMode
-                  ? "text-yellow-300 hover:text-yellow-400"
-                  : "text-indigo-600 hover:text-indigo-800"
-              }`}
+                  ? "bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white"
+                  : "bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white"
+              } transition-all`}
               aria-label={
                 isDarkMode ? "Switch to light mode" : "Switch to dark mode"
               }
@@ -498,7 +498,7 @@ const Header = ({ isDarkMode, toggleDarkMode }) => {
             </button>
 
             <a href="/dashboard" className="group">
-              <div className="w-10 h-10 text-light-gradient hover:from-teal-500 hover:to-indigo-600 rounded-full flex items-center justify-center transition-all duration-300 shadow-md hover:shadow-lg hover:scale-105">
+              <div className="w-10 h-10 bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 rounded-full flex items-center justify-center transition-all duration-300 shadow-md hover:shadow-lg hover:scale-105">
                 <span className="text-white">
                   {/* User placeholder icon */}
                   <svg
@@ -524,11 +524,11 @@ const Header = ({ isDarkMode, toggleDarkMode }) => {
           <div className="flex md:hidden items-center space-x-4">
             <button
               onClick={toggleDarkMode}
-              className={`p-2 rounded-full transition-colors duration-300 ${
+              className={`p-2 rounded-full ${
                 isDarkMode
-                  ? "text-yellow-300 hover:text-yellow-400"
-                  : "text-indigo-600 hover:text-indigo-800"
-              }`}
+                  ? "bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white"
+                  : "bg-gradient-to-r from-teal-400 to-indigo-500 hover:from-teal-500 hover:to-indigo-600 text-white"
+              } transition-all`}
               aria-label={
                 isDarkMode ? "Switch to light mode" : "Switch to dark mode"
               }


### PR DESCRIPTION
## Summary
- restore gradient backgrounds for dark mode toggle and dashboard button
- restore gradient styles for connect wallet button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d027f54d88322b5dd326bedd938ba