### PR TITLE
Switch to black logo in light mode

### DIFF
--- a/components/AdminOverview/AdminOverview.jsx
+++ b/components/AdminOverview/AdminOverview.jsx
@@ -147,7 +147,7 @@ const AdminOverview = ({ isDarkMode }) => {
       <span className="text-blue-500">
         {" "}
         <img
-          src="/SavitriNetwork.png"
+          src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
           style={{
             width: ".9rem",
           }}

--- a/components/Global/MobileHeader.jsx
+++ b/components/Global/MobileHeader.jsx
@@ -17,7 +17,7 @@ const MobileHeader = ({ isDarkMode, setIsSidebarOpen, isSidebarOpen }) => {
             style={{
               width: "3rem",
             }}
-            src="/SavitriNetwork.png"
+            src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
             alt=""
             srcset=""
           />

--- a/components/Global/Sidebar.jsx
+++ b/components/Global/Sidebar.jsx
@@ -211,7 +211,7 @@ const Sidebar = ({
               style={{
                 width: "3rem",
               }}
-              src="/SavitriNetwork.png"
+              src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
               alt=""
               srcset=""
             />

--- a/components/HomePage/FooterComponent.jsx
+++ b/components/HomePage/FooterComponent.jsx
@@ -72,7 +72,10 @@ const FooterComponent = ({ isDarkMode }) => {
                   isDarkMode ? "bg-[#0E0B12]" : "bg-gray-50"
                 }`}
               >
-                <img src="/SavitriNetwork.png" alt="" />
+                <img
+                  src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
+                  alt=""
+                />
               </div>
             </div>
           </div>

--- a/components/HomePage/Header.jsx
+++ b/components/HomePage/Header.jsx
@@ -296,7 +296,7 @@ const Header = ({ isDarkMode, toggleDarkMode }) => {
                 <div className="absolute inset-0 "></div>
                 <div className="absolute inset-1 flex items-center justify-center">
                   <img
-                    src="/SavitriNetwork.png"
+                    src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
                     alt="Logo"
                     className="w-full h-full object-contain"
                   />
@@ -654,7 +654,7 @@ const Header = ({ isDarkMode, toggleDarkMode }) => {
                   <div className="absolute inset-0 "></div>
                   <div className="absolute inset-1 flex items-center justify-center ">
                     <img
-                      src="/SavitriNetwork.png"
+                      src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
                       alt="Logo"
                       className="w-12 h-12 object-contain"
                     />

--- a/components/UserDashboard/UserDashboard.jsx
+++ b/components/UserDashboard/UserDashboard.jsx
@@ -510,7 +510,7 @@ const UserDashboard = ({ isDarkMode }) => {
                             style={{
                               width: "3rem",
                             }}
-                            src="/SavitriNetwork.png"
+                            src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
                             alt=""
                             srcset=""
                           />

--- a/components/WithdrawTokens/WithdrawTokens.jsx
+++ b/components/WithdrawTokens/WithdrawTokens.jsx
@@ -98,7 +98,7 @@ const WithdrawTokens = ({ isDarkMode }) => {
         return (
           <span className="text-blue-500">
             <img
-              src="/SavitriNetwork.png"
+              src={isDarkMode ? "/SavitriNetwork.png" : "/SavitriNetworkBlack.png"}
               style={{
                 width: "1rem",
               }}


### PR DESCRIPTION
## Summary
- tweak header, sidebar, footer, dashboard and other components to use `SavitriNetworkBlack.png` when light mode is active

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688d0da8eb1c83229ab1ee31f622fe15