### PR TITLE
fix: handle missing clipboard API

### DIFF
--- a/components/HomePage/TokenomicsComponent.jsx
+++ b/components/HomePage/TokenomicsComponent.jsx
@@ -97,7 +97,19 @@ const TokenomicsComponent = ({ isDarkMode }) => {
   };
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(FSX_ADDRESS);
+    if (typeof navigator !== "undefined" && navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(FSX_ADDRESS);
+    } else {
+      const textarea = document.createElement("textarea");
+      textarea.value = FSX_ADDRESS;
+      textarea.style.position = "fixed";
+      textarea.style.left = "-9999px";
+      document.body.appendChild(textarea);
+      textarea.focus();
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+    }
     setCopiedAddress(true);
     setTimeout(() => setCopiedAddress(false), 2000);
   };


### PR DESCRIPTION
## Summary
- handle missing `navigator.clipboard` in Tokenomics component with fallback textarea copy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: React lint errors, etc.)

------
https://chatgpt.com/codex/tasks/task_e_6890ae4982408322b8f3f1d7a05e837c