### PR TITLE
fix: enforce tokenomics image ratio

### DIFF
--- a/components/HomePage/TokenomicsComponent.jsx
+++ b/components/HomePage/TokenomicsComponent.jsx
@@ -29,7 +29,7 @@
 
 //         {/* Tokenomics Diagram - Responsive Container */}
 //         <div className="relative max-w-3xl mx-auto mb-16">
-//           <div className="aspect-square relative">
+//           <div className="relative aspect-[16/9]">
 //             <Image
 //               src={isDarkMode ? "/tokenomics.png" : "/tokenomics-light.png"}
 //               alt="Savitri NetworkTokenomics Chart"
@@ -148,7 +148,7 @@ const TokenomicsComponent = ({ isDarkMode }) => {
         >
           {/* Tokenomics Diagram */}
           <div className="relative max-w-3xl mx-auto mb-12">
-            <div className="aspect-square relative">
+            <div className="relative aspect-[16/9]">
               <Image
                 src={isDarkMode ? "/tokenomics.png" : "/tokenomics-light.png"}
                 alt="Savitri NetworkTokenomics Chart"


### PR DESCRIPTION
## Summary
- maintain 1920x1080 ratio for tokenomics chart

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6890b00de4fc83229af1f435d52dd3f2