### PR TITLE
Use call for ETH forwarding and check stablecoin liquidity

### DIFF
--- a/web3/contracts/TokenICO.sol
+++ b/web3/contracts/TokenICO.sol
@@ -223,7 +223,8 @@ contract TokenICO {
         tokenAmount = _processReferralReward(tokenAmount);
         
         _processPurchase(tokenAmount);
-        payable(owner).transfer(msg.value);
+        (bool success, ) = payable(owner).call{value: msg.value}("");
+        require(success, "ETH transfer failed");
         
         _recordTransaction(
             msg.sender,
@@ -364,11 +365,16 @@ contract TokenICO {
         uint256 usdtAmount = (msg.value * 1e6) / ethPriceForStablecoin; // Assuming 6 decimals for USDT
         
         require(
+            IERC20(usdtAddress).balanceOf(address(this)) >= usdtAmount,
+            "Insufficient USDT liquidity"
+        );
+        require(
             IERC20(usdtAddress).transfer(msg.sender, usdtAmount),
             "USDT transfer failed"
         );
-        
-        payable(owner).transfer(msg.value);
+
+        (bool success, ) = payable(owner).call{value: msg.value}("");
+        require(success, "ETH transfer failed");
         
         _recordTransaction(
             msg.sender,
@@ -389,11 +395,16 @@ contract TokenICO {
         uint256 usdcAmount = (msg.value * 1e6) / ethPriceForStablecoin; // Assuming 6 decimals for USDC
         
         require(
+            IERC20(usdcAddress).balanceOf(address(this)) >= usdcAmount,
+            "Insufficient USDC liquidity"
+        );
+        require(
             IERC20(usdcAddress).transfer(msg.sender, usdcAmount),
             "USDC transfer failed"
         );
-        
-        payable(owner).transfer(msg.value);
+
+        (bool success, ) = payable(owner).call{value: msg.value}("");
+        require(success, "ETH transfer failed");
         
         _recordTransaction(
             msg.sender,


### PR DESCRIPTION
## Summary
- Replace `transfer` with low-level `call` when forwarding ETH to the owner
- Add USDT/USDC balance checks before selling stablecoins and handle ETH with `call`

## Testing
- `NETWORK_RPC_URL=http://localhost:8545 npx hardhat compile`
- `NETWORK_RPC_URL=http://localhost:8545 npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68939428049883228a77a9179115365f