### PR TITLE
Switch presale to BNB native with ETH token option

### DIFF
--- a/components/AdminOverview/AdminOverview.jsx
+++ b/components/AdminOverview/AdminOverview.jsx
@@ -6,10 +6,10 @@ import {
   FaExchangeAlt,
   FaHistory,
   FaWallet,
-  FaEthereum,
   FaSyncAlt,
 } from "react-icons/fa";
-import { SiTether } from "react-icons/si";
+import { SiTether, SiBinance } from "react-icons/si";
+import { FaEthereum } from "react-icons/fa";
 import { useWeb3 } from "../../context/Web3Provider";
 import { Header } from "../index";
 
@@ -33,7 +33,7 @@ const AdminOverview = ({ isDarkMode }) => {
     connectWallet,
     disconnectWallet,
     switchNetwork,
-    buyWithETH,
+    buyWithBNB,
     buyWithUSDT,
     buyWithUSDC,
 
@@ -101,7 +101,7 @@ const AdminOverview = ({ isDarkMode }) => {
   // Helper function to format addresses
   const formatAddress = (address) => {
     if (!address || address === "0x0000000000000000000000000000000000000000")
-      return "ETH";
+      return "BNB";
     return `${address.substring(0, 6)}...${address.substring(
       address.length - 4
     )}`;
@@ -115,9 +115,10 @@ const AdminOverview = ({ isDarkMode }) => {
   // Helper function to determine token name
   const getTokenName = (address) => {
     if (!address || address === "0x0000000000000000000000000000000000000000")
-      return "ETH";
+      return "BNB";
     if (address === contractInfo.usdtAddress) return "USDT";
     if (address === contractInfo.usdcAddress) return "USDC";
+    if (address === contractInfo.ethAddress) return "ETH";
     if (address === contractInfo.fsxAddress) return `${TOKEN_SYMBOL}`;
     return formatAddress(address);
   };
@@ -125,6 +126,9 @@ const AdminOverview = ({ isDarkMode }) => {
   /// Helper function to get token icon
   const getTokenIcon = (address) => {
     if (!address || address === "0x0000000000000000000000000000000000000000") {
+      return <SiBinance className="text-yellow-400" />;
+    }
+    if (address === contractInfo.ethAddress) {
       return <FaEthereum className="text-[#627EEA]" />;
     }
     if (address === contractInfo.usdtAddress) {
@@ -388,15 +392,15 @@ const AdminOverview = ({ isDarkMode }) => {
                           <p
                             className={`${theme.text} font-bold text-lg sm:text-xl`}
                           >
-                            {contractInfo.ethPrice} {CURRENCY}
+                              {contractInfo.bnbPrice} {CURRENCY}
                           </p>
                         </div>
                         <div>
                           <h3 className="text-gray-400 mb-2">
-                            Stablecoin Price (ETH)
+                            Stablecoin Price (BNB)
                           </h3>
                           <p className="text-white font-bold text-lg sm:text-xl">
-                            {contractInfo.stablecoinPrice} ETH
+                            {contractInfo.stablecoinPrice} BNB
                           </p>
                         </div>
                       </div>
@@ -643,7 +647,7 @@ const AdminOverview = ({ isDarkMode }) => {
                               >
                                 {tx.tokenIn ===
                                 "0x0000000000000000000000000000000000000000"
-                                  ? tx.amountIn + " ETH"
+                                  ? tx.amountIn + " BNB"
                                   : tx.amountIn +
                                     " " +
                                     getTokenName(tx.tokenInAddress)}

--- a/components/Global/Sidebar.jsx
+++ b/components/Global/Sidebar.jsx
@@ -49,7 +49,7 @@ const Sidebar = ({
     connectWallet,
     disconnectWallet,
     switchNetwork,
-    buyWithETH,
+    buyWithBNB,
     buyWithUSDT,
     buyWithUSDC,
 

--- a/components/TokenSale/TokenSale.jsx
+++ b/components/TokenSale/TokenSale.jsx
@@ -32,10 +32,10 @@ const TokenSale = ({ isDarkMode }) => {
     connectWallet,
     disconnectWallet,
     switchNetwork,
-    buyWithETH,
+    buyWithBNB,
     buyWithUSDT,
     buyWithUSDC,
-    buyWithBNB,
+    buyWithETH,
     buyWithBTC,
     buyWithSOL,
     reCall,
@@ -54,11 +54,11 @@ const TokenSale = ({ isDarkMode }) => {
   } = useWeb3();
 
   const [transactions, setTransactions] = useState([]);
-  const [activeTab, setActiveTab] = useState("buyWithETH");
-  const [ethAmount, setEthAmount] = useState("");
+  const [activeTab, setActiveTab] = useState("buyWithBNB");
+  const [bnbAmount, setBnbAmount] = useState("");
   const [usdtAmount, setUsdtAmount] = useState("");
   const [usdcAmount, setUsdcAmount] = useState("");
-  const [bnbAmount, setBnbAmount] = useState("");
+  const [ethAmount, setEthAmount] = useState("");
   const [btcAmount, setBtcAmount] = useState("");
   const [solAmount, setSolAmount] = useState("");
   const [calculatedTokens, setCalculatedTokens] = useState("0");
@@ -123,8 +123,9 @@ const TokenSale = ({ isDarkMode }) => {
 
   // Calculate tokens based on input and payment method
   useEffect(() => {
-    if (activeTab === "buyWithETH" && ethAmount) {
-      const tokens = parseFloat(ethAmount) / parseFloat(contractInfo.ethPrice);
+    if (activeTab === "buyWithBNB" && bnbAmount) {
+      const tokens =
+        parseFloat(bnbAmount) / parseFloat(contractInfo.bnbPrice);
       setCalculatedTokens(tokens.toLocaleString());
     } else if (activeTab === "buyWithUSDT" && usdtAmount) {
       const tokens =
@@ -134,9 +135,9 @@ const TokenSale = ({ isDarkMode }) => {
       const tokens =
         parseFloat(usdcAmount) * parseFloat(contractInfo.usdcTokenRatio);
       setCalculatedTokens(tokens.toLocaleString());
-    } else if (activeTab === "buyWithBNB" && bnbAmount) {
+    } else if (activeTab === "buyWithETH" && ethAmount) {
       const tokens =
-        parseFloat(bnbAmount) * parseFloat(contractInfo.bnbTokenRatio);
+        parseFloat(ethAmount) * parseFloat(contractInfo.ethTokenRatio);
       setCalculatedTokens(tokens.toLocaleString());
     } else if (activeTab === "buyWithBTC" && btcAmount) {
       const tokens =
@@ -151,10 +152,10 @@ const TokenSale = ({ isDarkMode }) => {
     }
   }, [
     activeTab,
-    ethAmount,
+    bnbAmount,
     usdtAmount,
     usdcAmount,
-    bnbAmount,
+    ethAmount,
     btcAmount,
     solAmount,
   ]);
@@ -165,8 +166,8 @@ const TokenSale = ({ isDarkMode }) => {
     setIsLoading(true);
 
     // In a real implementation, you would call contract methods:
-    if (activeTab === "buyWithETH") {
-      const transaction = await buyWithETH(ethAmount);
+    if (activeTab === "buyWithBNB") {
+      const transaction = await buyWithBNB(bnbAmount);
       console.log(transaction);
     } else if (activeTab === "buyWithUSDT") {
       // Assuming USDT has 6 decimals
@@ -176,8 +177,8 @@ const TokenSale = ({ isDarkMode }) => {
       // Assuming USDC has 6 decimals
       const transaction = await buyWithUSDC(usdcAmount);
       console.log(transaction);
-    } else if (activeTab === "buyWithBNB") {
-      const transaction = await buyWithBNB(bnbAmount);
+    } else if (activeTab === "buyWithETH") {
+      const transaction = await buyWithETH(ethAmount);
       console.log(transaction);
     } else if (activeTab === "buyWithBTC") {
       const transaction = await buyWithBTC(btcAmount);
@@ -187,10 +188,10 @@ const TokenSale = ({ isDarkMode }) => {
       console.log(transaction);
     }
 
-    if (activeTab === "buyWithETH") setEthAmount("");
+    if (activeTab === "buyWithBNB") setBnbAmount("");
     if (activeTab === "buyWithUSDT") setUsdtAmount("");
     if (activeTab === "buyWithUSDC") setUsdcAmount("");
-    if (activeTab === "buyWithBNB") setBnbAmount("");
+    if (activeTab === "buyWithETH") setEthAmount("");
     if (activeTab === "buyWithBTC") setBtcAmount("");
     if (activeTab === "buyWithSOL") setSolAmount("");
 
@@ -378,15 +379,15 @@ const TokenSale = ({ isDarkMode }) => {
               {/* Payment Method Tabs */}
               <div className={`flex border-b ${theme.border}`}>
                 <button
-                  onClick={() => setActiveTab("buyWithETH")}
+                  onClick={() => setActiveTab("buyWithBNB")}
                   className={`flex-1 py-4 px-6 flex justify-center items-center gap-2 ${
-                    activeTab === "buyWithETH"
+                    activeTab === "buyWithBNB"
                       ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
                       : `${theme.textSecondary} ${theme.hover}`
                   }`}
                 >
-                  <FaEthereum />
-                  <span>{CURRENCY}</span>
+                  <SiBinance className="text-yellow-400" />
+                  <span>BNB</span>
                 </button>
                 <button
                   onClick={() => setActiveTab("buyWithUSDT")}
@@ -418,15 +419,15 @@ const TokenSale = ({ isDarkMode }) => {
                   <span>USDC</span>
                 </button>
                 <button
-                  onClick={() => setActiveTab("buyWithBNB")}
+                  onClick={() => setActiveTab("buyWithETH")}
                   className={`flex-1 py-4 px-6 flex justify-center items-center gap-2 ${
-                    activeTab === "buyWithBNB"
+                    activeTab === "buyWithETH"
                       ? "text-light-gradient hover:from-teal-500 hover:to-indigo-600 text-white"
                       : `${theme.textSecondary} ${theme.hover}`
                   }`}
                 >
-                  <SiBinance className="text-yellow-400" />
-                  <span>BNB</span>
+                  <FaEthereum />
+                  <span>ETH</span>
                 </button>
                 <button
                   onClick={() => setActiveTab("buyWithBTC")}
@@ -470,17 +471,17 @@ const TokenSale = ({ isDarkMode }) => {
                   </div>
                 ) : (
                   <form onSubmit={handlePurchase} className="space-y-6">
-                    {/* ETH Purchase Form */}
-                    {activeTab === "buyWithETH" && (
+                    {/* BNB Purchase Form */}
+                    {activeTab === "buyWithBNB" && (
                       <div>
                         <label className={`block ${theme.textSecondary} mb-2`}>
-                          {CURRENCY} Amount
+                          BNB Amount
                         </label>
                         <div className="relative">
                           <input
                             type="number"
-                            value={ethAmount}
-                            onChange={(e) => setEthAmount(e.target.value)}
+                            value={bnbAmount}
+                            onChange={(e) => setBnbAmount(e.target.value)}
                             placeholder="0.0"
                             step="0.01"
                             min="0"
@@ -488,16 +489,14 @@ const TokenSale = ({ isDarkMode }) => {
                             required
                           />
                           <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2">
-                            <FaEthereum className="text-[#627EEA]" />
-                            <span className={theme.textSecondary}>
-                              {CURRENCY}
-                            </span>
+                            <SiBinance className="text-yellow-400" />
+                            <span className={theme.textSecondary}>BNB</span>
                           </div>
                         </div>
                         <p className={`text-sm ${theme.textMuted} mt-2`}>
-                          1 {CURRENCY} ={" "}
+                          1 BNB ={" "}
                           {(
-                            1 / parseFloat(Number(contractInfo?.ethPrice) || 1)
+                            1 / parseFloat(Number(contractInfo?.bnbPrice) || 1)
                           ).toLocaleString()}{" "}
                           {TOKEN_SYMBOL}
                         </p>
@@ -575,17 +574,17 @@ const TokenSale = ({ isDarkMode }) => {
                       </div>
                     )}
 
-                    {/* BNB Purchase Form */}
-                    {activeTab === "buyWithBNB" && (
+                    {/* ETH Purchase Form */}
+                    {activeTab === "buyWithETH" && (
                       <div>
                         <label className={`block ${theme.textSecondary} mb-2`}>
-                          BNB Amount
+                          ETH Amount
                         </label>
                         <div className="relative">
                           <input
                             type="number"
-                            value={bnbAmount}
-                            onChange={(e) => setBnbAmount(e.target.value)}
+                            value={ethAmount}
+                            onChange={(e) => setEthAmount(e.target.value)}
                             placeholder="0.0"
                             step="0.0001"
                             min="0"
@@ -593,14 +592,14 @@ const TokenSale = ({ isDarkMode }) => {
                             required
                           />
                           <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2">
-                            <SiBinance className="text-yellow-400" />
-                            <span className={theme.textSecondary}>BNB</span>
+                            <FaEthereum className="text-[#627EEA]" />
+                            <span className={theme.textSecondary}>ETH</span>
                           </div>
                         </div>
                         <p className={`text-sm ${theme.textMuted} mt-2`}>
-                          1 BNB ={" "}
+                          1 ETH ={" "}
                           {parseFloat(
-                            contractInfo?.bnbTokenRatio || 1
+                            contractInfo?.ethTokenRatio || 1
                           ).toLocaleString()}{" "}
                           {TOKEN_SYMBOL}
                         </p>
@@ -703,14 +702,14 @@ const TokenSale = ({ isDarkMode }) => {
                         : parseFloat(tokenBalances?.fsxBalance || 0) < 20
                         ? "Insufficient Token Supply"
                         : `Buy with ${
-                            activeTab === "buyWithETH"
-                              ? "ETH"
+                            activeTab === "buyWithBNB"
+                              ? "BNB"
                               : activeTab === "buyWithUSDT"
                               ? "USDT"
                               : activeTab === "buyWithUSDC"
                               ? "USDC"
-                              : activeTab === "buyWithBNB"
-                              ? "BNB"
+                              : activeTab === "buyWithETH"
+                              ? "ETH"
                               : activeTab === "buyWithBTC"
                               ? "BTC"
                               : "SOL"
@@ -777,9 +776,9 @@ const TokenSale = ({ isDarkMode }) => {
                             <td className="py-3 px-4">2024-02-25 10:30</td>
                             <td className="py-3 px-4">
                               <span className="flex items-center">
-                                {tx.tokenIn === "ETH" ? (
+                                {tx.tokenIn === "BNB" ? (
                                   <>
-                                    <FaEthereum className="mr-2 text-[#627EEA]" />
+                                    <SiBinance className="mr-2 text-yellow-400" />
                                     {tx.tokenIn} Purchase
                                   </>
                                 ) : tx.tokenIn === "USDT" ? (

--- a/context/Web3Provider.js
+++ b/context/Web3Provider.js
@@ -53,17 +53,18 @@ export const Web3Provider = ({ children }) => {
   const [contractInfo, setContractInfo] = useState({
     fsxAddress: null,
     fsxBalance: "0",
-    ethPrice: "0",
+    bnbPrice: "0",
     stablecoinPrice: "0",
     totalSold: "0",
     usdtAddress: null,
     usdcAddress: null,
     usdtTokenRatio: "0",
     usdcTokenRatio: "0",
-    bnbAddress: null,
+    ethAddress: null,
     btcAddress: null,
     solAddress: null,
     bnbTokenRatio: "0",
+    ethTokenRatio: "0",
     btcTokenRatio: "0",
     solTokenRatio: "0",
   });
@@ -71,13 +72,13 @@ export const Web3Provider = ({ children }) => {
   const [tokenBalances, setTokenBalances] = useState({
     fsxSupply: "0",
     userFsxBlanace: "0",
-    contractEthBalance: null,
-    userEthBalance: null,
-    userBNBBalance: "0",
+    contractBnbBalance: null,
+    userBnbBalance: null,
+    userETHBalance: "0",
     userBTCBalance: "0",
     userSOLBalance: "0",
     fsxBalance: "0",
-    ethPrice: "0",
+    bnbPrice: "0",
     stablecoinPrice: "0",
     usdtBalance: "0",
     usdcBalance: "0",
@@ -180,14 +181,15 @@ export const Web3Provider = ({ children }) => {
 
         // Fetch basic contract info
         const info = await readOnlyContract.getContractInfo();
-        const bnbAddr = await readOnlyContract.bnbAddress();
+        const ethAddr = await readOnlyContract.ethAddress();
         const btcAddr = await readOnlyContract.btcAddress();
         const solAddr = await readOnlyContract.solAddress();
         const bnbRatio = await readOnlyContract.bnbRatio();
+        const ethRatio = await readOnlyContract.ethRatio();
         const btcRatio = await readOnlyContract.btcRatio();
         const solRatio = await readOnlyContract.solRatio();
 
-        console.log("BNB ADDDRESs", bnbAddr)
+        console.log("ETH ADDDRESs", ethAddr)
 
         // Create token contract after we have the address from info
         const tokenContract = new ethers.Contract(
@@ -195,7 +197,7 @@ export const Web3Provider = ({ children }) => {
           erc20Abi,
           currentProvider
         );
-        const bnbContract = new ethers.Contract(bnbAddr, erc20Abi, currentProvider);
+        const ethContract = new ethers.Contract(ethAddr, erc20Abi, currentProvider);
         const btcContract = new ethers.Contract(btcAddr, erc20Abi, currentProvider);
         const solContract = new ethers.Contract(solAddr, erc20Abi, currentProvider);
 
@@ -213,7 +215,7 @@ export const Web3Provider = ({ children }) => {
         let balanceWei = ethers.BigNumber.from(0);
         let usdtBalanceMy = ethers.BigNumber.from(0);
         let usdcBalanceMy = ethers.BigNumber.from(0);
-        let bnbBalanceMy = ethers.BigNumber.from(0);
+        let ethBalanceMy = ethers.BigNumber.from(0);
         let btcBalanceMy = ethers.BigNumber.from(0);
         let solBalanceMy = ethers.BigNumber.from(0);
 
@@ -224,7 +226,7 @@ export const Web3Provider = ({ children }) => {
             balanceWei,
             usdtBalanceMy,
             usdcBalanceMy,
-            bnbBalanceMy,
+            ethBalanceMy,
             btcBalanceMy,
             solBalanceMy,
           ] = await Promise.all([
@@ -232,7 +234,7 @@ export const Web3Provider = ({ children }) => {
             currentProvider.getBalance(address),
             readOnlyUsdtContract.balanceOf(address),
             readOnlyUsdcContract.balanceOf(address),
-            bnbContract.balanceOf(address),
+            ethContract.balanceOf(address),
             btcContract.balanceOf(address),
             solContract.balanceOf(address),
           ]);
@@ -249,7 +251,7 @@ export const Web3Provider = ({ children }) => {
         setContractInfo({
           fsxAddress: info.tokenAddress,
           fsxBalance: formatAmount(info.tokenBalance, TOKEN_DECIMALS),
-          ethPrice: formatAmount(info.ethPrice, TOKEN_DECIMALS, 6),
+          bnbPrice: formatAmount(info.bnbPrice, TOKEN_DECIMALS, 6),
           stablecoinPrice: formatAmount(
             info.stablecoinPrice,
             TOKEN_DECIMALS,
@@ -260,10 +262,11 @@ export const Web3Provider = ({ children }) => {
           usdcAddress: info.usdcAddr,
           usdtTokenRatio: info.usdtTokenRatio.toString(),
           usdcTokenRatio: info.usdcTokenRatio.toString(),
-          bnbAddress: bnbAddr,
+          ethAddress: ethAddr,
           btcAddress: btcAddr,
           solAddress: solAddr,
           bnbTokenRatio: bnbRatio.toString(),
+          ethTokenRatio: ethRatio.toString(),
           btcTokenRatio: btcRatio.toString(),
           solTokenRatio: solRatio.toString(),
         });
@@ -272,13 +275,13 @@ export const Web3Provider = ({ children }) => {
         setTokenBalances({
           fsxSupply: formatAmount(rawSupply, TOKEN_DECIMALS),
           userFsxBlanace: formatAmount(userFsxBalance, TOKEN_DECIMALS),
-          contractEthBalance: ethers.utils.formatEther(contractBalanceWei),
-          userEthBalance: ethers.utils.formatEther(balanceWei),
-          userBNBBalance: formatAmount(bnbBalanceMy, 18),
+          contractBnbBalance: ethers.utils.formatEther(contractBalanceWei),
+          userBnbBalance: ethers.utils.formatEther(balanceWei),
+          userETHBalance: formatAmount(ethBalanceMy, 18),
           userBTCBalance: formatAmount(btcBalanceMy, 8),
           userSOLBalance: formatAmount(solBalanceMy, 9),
           fsxBalance: formatAmount(balances.tokenBalance, TOKEN_DECIMALS),
-          ethPrice: formatAmount(info.ethPrice, TOKEN_DECIMALS, 6),
+          bnbPrice: formatAmount(info.bnbPrice, TOKEN_DECIMALS, 6),
           stablecoinPrice: formatAmount(info.stablecoinPrice, TOKEN_DECIMALS),
           usdtBalance: formatAmount(balances.usdtBalance, STABLE_DECIMALS),
           usdcBalance: formatAmount(balances.usdcBalance, STABLE_DECIMALS),
@@ -295,27 +298,27 @@ export const Web3Provider = ({ children }) => {
   }, [contract, address, provider, signer, reCall]);
 
   /// Contract interaction functions
-  const buyWithETH = async (ethAmount) => {
+  const buyWithBNB = async (bnbAmount) => {
     if (!contract || !address) return null;
     // Start a transaction toast notification
     const toastId = notify.start(
       `Initializing buy With ${CURRENCY} transaction...`
     );
     try {
-      const ethValue = ethers.utils.parseEther(ethAmount);
+      const bnbValue = ethers.utils.parseEther(bnbAmount);
 
       // Get current gas price and estimate gas
       const gasPrice = await signer.getGasPrice();
       const optimizedGasPrice = gasPrice.mul(85).div(100); // 85% of current gas price
 
-      const estimatedGas = await contract.estimateGas.buyWithETH({
-        value: ethValue.toString(),
+      const estimatedGas = await contract.estimateGas.buyWithBNB({
+        value: bnbValue.toString(),
       });
 
       const gasLimit = estimatedGas.mul(120).div(100); // Add 20% buffer
 
-      const tx = await contract.buyWithETH({
-        value: ethValue,
+      const tx = await contract.buyWithBNB({
+        value: bnbValue,
         gasPrice: optimizedGasPrice,
         gasLimit,
       });
@@ -324,13 +327,13 @@ export const Web3Provider = ({ children }) => {
       // Update notification for completed transaction
       notify.complete(
         toastId,
-        `Successfully purchased  ${ethAmount} ${TOKEN_SYMBOL}!`
+        `Successfully purchased  ${bnbAmount} ${TOKEN_SYMBOL}!`
       );
       return returnTransaction;
     } catch (error) {
       const { message: errorMessage, code: errorCode } = handleTransactionError(
         error,
-        "buying with ETH"
+        "buying with BNB"
       );
       console.log(errorMessage);
 
@@ -535,14 +538,14 @@ export const Web3Provider = ({ children }) => {
     }
   };
 
-  const buyWithBNB = async (bnbAmount) => {
+  const buyWithETH = async (ethAmount) => {
     if (!contract || !address) return null;
-    const toastId = notify.start(`Initializing buy With BNB transaction...`);
+    const toastId = notify.start(`Initializing buy With ETH transaction...`);
     try {
-      const parsedAmount = ethers.utils.parseUnits(bnbAmount, 18);
+      const parsedAmount = ethers.utils.parseUnits(ethAmount, 18);
 
-      const bnbContract = new ethers.Contract(
-        contractInfo.bnbAddress,
+      const ethContract = new ethers.Contract(
+        contractInfo.ethAddress,
         [
           "function approve(address spender, uint256 amount) public returns (bool)",
           "function allowance(address owner, address spender) view returns (uint256)",
@@ -550,39 +553,39 @@ export const Web3Provider = ({ children }) => {
         signer
       );
 
-      const currentAllowance = await bnbContract.allowance(address, CONTRACT_ADDRESS);
+      const currentAllowance = await ethContract.allowance(address, CONTRACT_ADDRESS);
 
       if (currentAllowance.lt(parsedAmount)) {
         const gasPrice = await signer.getGasPrice();
         const optimizedGasPrice = gasPrice.mul(85).div(100);
 
-        const approveTx = await bnbContract.approve(CONTRACT_ADDRESS, parsedAmount, {
+        const approveTx = await ethContract.approve(CONTRACT_ADDRESS, parsedAmount, {
           gasPrice: optimizedGasPrice,
         });
         await approveTx.wait();
-        notify.approve(toastId, "BNB spending approved!");
+        notify.approve(toastId, "ETH spending approved!");
       } else {
-        notify.update(toastId, "info", "BNB already approved, proceeding with purchase...");
+        notify.update(toastId, "info", "ETH already approved, proceeding with purchase...");
       }
 
       const gasPrice = await signer.getGasPrice();
       const optimizedGasPrice = gasPrice.mul(85).div(100);
 
-      const estimatedGas = await contract.estimateGas.buyWithBNB(parsedAmount);
+      const estimatedGas = await contract.estimateGas.buyWithETH(parsedAmount);
       const gasLimit = estimatedGas.mul(120).div(100);
 
-      const tx = await contract.buyWithBNB(parsedAmount, {
+      const tx = await contract.buyWithETH(parsedAmount, {
         gasPrice: optimizedGasPrice,
         gasLimit,
       });
       const returnTransaction = await tx.wait();
       setReCall(reCall + 1);
-      notify.complete(toastId, `Successfully purchased with ${bnbAmount} BNB!`);
+      notify.complete(toastId, `Successfully purchased with ${ethAmount} ETH!`);
       return returnTransaction;
     } catch (error) {
       const { message: errorMessage, code: errorCode } = handleTransactionError(
         error,
-        "buying with BNB"
+        "buying with ETH"
       );
       if (errorCode === "ACTION_REJECTED") {
         notify.reject(toastId, "Transaction rejected by user");
@@ -1343,6 +1346,7 @@ export const Web3Provider = ({ children }) => {
           btcAddr,
           solAddr,
           bnbRatio,
+          ethRatio,
           btcRatio,
           solRatio,
           usdtBalanceMy,
@@ -1350,10 +1354,11 @@ export const Web3Provider = ({ children }) => {
           balanceWei,
         ] = await Promise.all([
           contract.getContractInfo(),
-          contract.bnbAddress(),
+          contract.ethAddress(),
           contract.btcAddress(),
           contract.solAddress(),
           contract.bnbRatio(),
+          contract.ethRatio(),
           contract.btcRatio(),
           contract.solRatio(),
           usdtContract.balanceOf(address),
@@ -1369,16 +1374,16 @@ export const Web3Provider = ({ children }) => {
         );
 
         // Fetch additional data concurrently
-        const bnbContract = new ethers.Contract(bnbAddr, erc20Abi, provider);
+        const ethContract = new ethers.Contract(ethAddr, erc20Abi, provider);
         const btcContract = new ethers.Contract(btcAddr, erc20Abi, provider);
 
-        const [rawSupply, userFsxBalance, balances, totalPenaltyCollected, bnbBalanceMy, btcBalanceMy] =
+        const [rawSupply, userFsxBalance, balances, totalPenaltyCollected, ethBalanceMy, btcBalanceMy] =
           await Promise.all([
             tokenContract.totalSupply(),
             tokenContract.balanceOf(address),
             contract.getTokenBalances(),
             readOnlyContract.getTotalPenaltyCollected(),
-            bnbContract.balanceOf(address),
+            ethContract.balanceOf(address),
             btcContract.balanceOf(address),
           ]);
 
@@ -1392,7 +1397,7 @@ export const Web3Provider = ({ children }) => {
         setContractInfo({
           fsxAddress: info.tokenAddress,
           fsxBalance: formatAmount(info.tokenBalance, TOKEN_DECIMALS),
-          ethPrice: formatAmount(info.ethPrice, TOKEN_DECIMALS, 6),
+          bnbPrice: formatAmount(info.bnbPrice, TOKEN_DECIMALS, 6),
           stablecoinPrice: formatAmount(
             info.stablecoinPrice,
             TOKEN_DECIMALS,
@@ -1403,10 +1408,11 @@ export const Web3Provider = ({ children }) => {
           usdcAddress: info.usdcAddr,
           usdtTokenRatio: info.usdtTokenRatio.toString(),
           usdcTokenRatio: info.usdcTokenRatio.toString(),
-          bnbAddress: bnbAddr,
+          ethAddress: ethAddr,
           btcAddress: btcAddr,
           solAddress: solAddr,
           bnbTokenRatio: bnbRatio.toString(),
+          ethTokenRatio: ethRatio.toString(),
           btcTokenRatio: btcRatio.toString(),
           solTokenRatio: solRatio.toString(),
         });
@@ -1415,12 +1421,12 @@ export const Web3Provider = ({ children }) => {
         setTokenBalances({
           fsxSupply: formatAmount(rawSupply, TOKEN_DECIMALS),
           userFsxBlanace: formatAmount(userFsxBalance, TOKEN_DECIMALS),
-          contractEthBalance: ethers.utils.formatEther(contractBalanceWei),
-          userEthBalance: ethers.utils.formatEther(balanceWei),
-          userBNBBalance: formatAmount(bnbBalanceMy, TOKEN_DECIMALS),
+          contractBnbBalance: ethers.utils.formatEther(contractBalanceWei),
+          userBnbBalance: ethers.utils.formatEther(balanceWei),
+          userETHBalance: formatAmount(ethBalanceMy, TOKEN_DECIMALS),
           userBTCBalance: formatAmount(btcBalanceMy, TOKEN_DECIMALS),
           fsxBalance: formatAmount(balances.tokenBalance, TOKEN_DECIMALS),
-          ethPrice: formatAmount(info.ethPrice, TOKEN_DECIMALS, 6),
+          bnbPrice: formatAmount(info.bnbPrice, TOKEN_DECIMALS, 6),
           stablecoinPrice: formatAmount(info.stablecoinPrice, TOKEN_DECIMALS),
           usdtBalance: formatAmount(balances.usdtBalance, STABLE_DECIMALS),
           usdcBalance: formatAmount(balances.usdcBalance, STABLE_DECIMALS),
@@ -1890,11 +1896,12 @@ export const Web3Provider = ({ children }) => {
     try {
       // Get basic contract info as you already do
       const info = await contract.getContractInfo();
-      const [bnbAddr, btcAddr, solAddr, bnbRatio, btcRatio, solRatio] = await Promise.all([
-        contract.bnbAddress(),
+      const [ethAddr, btcAddr, solAddr, bnbRatio, ethRatio, btcRatio, solRatio] = await Promise.all([
+        contract.ethAddress(),
         contract.btcAddress(),
         contract.solAddress(),
         contract.bnbRatio(),
+        contract.ethRatio(),
         contract.btcRatio(),
         contract.solRatio(),
       ]);
@@ -1913,17 +1920,18 @@ export const Web3Provider = ({ children }) => {
         // Existing contract info
         saleToken: info.tokenAddress,
         fsxBalance: ethers.utils.formatUnits(info.tokenBalance, 18),
-        ethPrice: ethers.utils.formatUnits(info.ethPrice, 18),
+        bnbPrice: ethers.utils.formatUnits(info.bnbPrice, 18),
         stablecoinPrice: ethers.utils.formatUnits(info.stablecoinPrice, 18),
         totalSold: ethers.utils.formatUnits(info.totalSold, 18),
         usdtAddress: info.usdtAddr,
         usdcAddress: info.usdcAddr,
         usdtTokenRatio: info.usdtTokenRatio.toString(),
         usdcTokenRatio: info.usdcTokenRatio.toString(),
-        bnbAddress: bnbAddr,
+        ethAddress: ethAddr,
         btcAddress: btcAddr,
         solAddress: solAddr,
         bnbTokenRatio: bnbRatio.toString(),
+        ethTokenRatio: ethRatio.toString(),
         btcTokenRatio: btcRatio.toString(),
         solTokenRatio: solRatio.toString(),
 
@@ -2197,10 +2205,10 @@ export const Web3Provider = ({ children }) => {
     error,
     reCall,
     globalLoad,
-    buyWithETH,
+    buyWithBNB,
     buyWithUSDT,
     buyWithUSDC,
-    buyWithBNB,
+    buyWithETH,
     buyWithBTC,
     buyWithSOL,
     buyUSDT,


### PR DESCRIPTION
## Summary
- treat BNB as the native currency and accept ERC-20 ETH payments
- surface BNB and ETH helpers in the web3 context
- update admin and sale flows to show BNB pricing and options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689597942ca48322987a644d44a49ee3