### PR TITLE
feat: add referral voucher support

### DIFF
--- a/components/HomePage/HeroSection.jsx
+++ b/components/HomePage/HeroSection.jsx
@@ -34,6 +34,8 @@ const HeroSection = ({ isDarkMode, setIsReferralPopupOpen }) => {
     getReferralInfo,
     checkReferralCode,
     registerReferrer,
+    boundReferrer,
+    formatAddress,
   } = useWeb3();
 
   const [selectedToken, setSelectedToken] = useState("BNB");
@@ -485,6 +487,11 @@ const HeroSection = ({ isDarkMode, setIsReferralPopupOpen }) => {
 
       {/* Main content */}
       <div className="container mx-auto px-4 py-28 md:py-32 relative z-10">
+        {boundReferrer && (
+          <div className={`mb-4 ${textColor}`}>
+            Referrer: {formatAddress(boundReferrer)}
+          </div>
+        )}
         <div className="flex flex-col md:flex-row items-center justify-between gap-12 md:gap-16">
           {/* Left side content - Text and graphics */}
           <div className="w-full md:w-1/2 flex flex-col items-center text-left">

--- a/components/StablecoinPurchase/StablecoinPurchase.jsx
+++ b/components/StablecoinPurchase/StablecoinPurchase.jsx
@@ -54,6 +54,7 @@ const StablecoinPurchase = ({ isDarkMode }) => {
     isOwner,
     setReCall,
     reCall,
+    boundReferrer,
   } = useWeb3();
   const [selectedStablecoin, setSelectedStablecoin] = useState("USDT");
   const [ethAmount, setEthAmount] = useState("");
@@ -221,6 +222,11 @@ const StablecoinPurchase = ({ isDarkMode }) => {
   return (
     <>
       <Header theme={theme} title="Purchase Stablecoins" />
+      {boundReferrer && (
+        <div className={`mb-4 ${theme.text}`}>
+          Referrer: {formatAddress(boundReferrer)}
+        </div>
+      )}
       <div className={`${theme.mainBg} min-h-screen `}>
         <div className=" mx-auto">
           {/* Header */}

--- a/components/TokenSale/TokenSale.jsx
+++ b/components/TokenSale/TokenSale.jsx
@@ -38,6 +38,7 @@ const TokenSale = ({ isDarkMode }) => {
     buyWithETH,
     buyWithBTC,
     buyWithSOL,
+    boundReferrer,
     reCall,
     updateTokenPrice,
     updateUSDT,
@@ -242,6 +243,11 @@ const TokenSale = ({ isDarkMode }) => {
   return (
     <>
       <Header theme={theme} title="Token Sale" />
+      {boundReferrer && (
+        <div className={`mb-4 px-4 ${theme.text}`}>
+          Referrer: {formatAddress(boundReferrer)}
+        </div>
+      )}
       <div className="">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           {/* Token Stats Card */}


### PR DESCRIPTION
## Summary
- capture referral addresses from query string or storage
- fetch server-side vouchers before token purchases
- show bound referrer after successful buy

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (errors and warnings)


------
https://chatgpt.com/codex/tasks/task_e_689e5386e6c48322b206abcf8558ed27