### PR TITLE
Add delegation and sweeper checks to presale contract

### DIFF
--- a/web3/contracts/mock/DelegationCheckerMock.sol
+++ b/web3/contracts/mock/DelegationCheckerMock.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+contract DelegationCheckerMock {
+    mapping(address => bool) public delegated;
+
+    function setDelegated(address user, bool status) external {
+        delegated[user] = status;
+    }
+
+    function isDelegated(address user) external view returns (bool) {
+        return delegated[user];
+    }
+}

--- a/web3/test/delegationAndSweeper.test.js
+++ b/web3/test/delegationAndSweeper.test.js
@@ -1,0 +1,48 @@
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+async function setupICO() {
+  const [owner, buyer, other] = await ethers.getSigners();
+
+  const Sav = await ethers.getContractFactory("SavitriCoin");
+  const sav = await Sav.deploy();
+  await sav.deployed();
+
+  const ICO = await ethers.getContractFactory("TokenICO");
+  const ico = await ICO.deploy();
+  await ico.deployed();
+
+  await ico.connect(owner).setSaleToken(sav.address);
+  const saleLiquidity = ethers.utils.parseEther("1000000");
+  await sav.connect(owner).transfer(ico.address, saleLiquidity);
+  await sav.connect(owner).setAllowedSender(ico.address, true);
+
+  return { owner, buyer, other, sav, ico };
+}
+
+describe("TokenICO security checks", function () {
+  it("reverts purchases from sweeper-listed addresses", async function () {
+    const { owner, buyer, ico } = await setupICO();
+
+    await ico.connect(owner).setSweeper(buyer.address, true);
+
+    await expect(
+      ico.connect(buyer).buyWithBNB({ value: ethers.utils.parseEther("1") })
+    ).to.be.revertedWith("Blocked sweeper");
+  });
+
+  it("reverts purchases from delegated wallets", async function () {
+    const { owner, buyer, ico } = await setupICO();
+
+    const Checker = await ethers.getContractFactory("DelegationCheckerMock");
+    const checker = await Checker.deploy();
+    await checker.deployed();
+
+    await ico.connect(owner).setDelegationChecker(checker.address);
+    await checker.setDelegated(buyer.address, true);
+
+    await expect(
+      ico.connect(buyer).buyWithBNB({ value: ethers.utils.parseEther("1") })
+    ).to.be.revertedWith("Delegated wallet");
+  });
+});


### PR DESCRIPTION
## Summary
- reject delegated wallets via `IDelegationChecker`
- maintain blacklist of known sweeper addresses
- centralize address validation in `_ensureNotBlocked`
- add unit tests for sweeper and delegation checks

## Testing
- `npx hardhat compile`
- `npx hardhat test`


------
https://chatgpt.com/codex/tasks/task_e_68a1eac297b48322a0d5394a15bb0f43