### PR TITLE
fix: correct countdown timer units

### DIFF
--- a/components/HomePage/HeroSection.jsx
+++ b/components/HomePage/HeroSection.jsx
@@ -342,7 +342,8 @@ useEffect(() => {
 
       // Timing state for countdown
       setSaleStartTs(startBN.toNumber());
-      setIntervalSec((isWl ? wlIntBN : pubIntBN).toNumber());
+      // Contract returns interval lengths in minutes – convert to seconds for the countdown
+      setIntervalSec((isWl ? wlIntBN : pubIntBN).toNumber() * 60);
     } catch (e) {
       console.error("price/timing load error", e);
     }


### PR DESCRIPTION
## Summary
- fix countdown timer by converting contract interval minutes to seconds

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3f6687ff88322b3274c8e8de1134f