### PR TITLE
Refresh Hero data on wallet connect

### DIFF
--- a/components/HomePage/HeroSection.jsx
+++ b/components/HomePage/HeroSection.jsx
@@ -68,6 +68,7 @@ const HeroSection = ({ isDarkMode, setIsReferralPopupOpen }) => {
     boundReferrer,
     formatAddress,
     eligibility,
+    refreshContractData,
   } = useWeb3();
 
   const [selectedToken, setSelectedToken] = useState("BNB");
@@ -444,6 +445,12 @@ useEffect(() => {
   useEffect(() => {
     setTokenAmount(calculateTokenAmount(inputAmount, selectedToken));
   }, [inputAmount, selectedToken, livePriceBNB, prices]);
+
+  useEffect(() => {
+    if (account) {
+      refreshContractData();
+    }
+  }, [account, refreshContractData]);
 
   // Execute purchase based on selected token
   const executePurchase = async () => {

--- a/components/TokenSale/TokenSale.jsx
+++ b/components/TokenSale/TokenSale.jsx
@@ -124,6 +124,13 @@ const TokenSale = ({ isDarkMode }) => {
     fetchUserData();
   }, [account, reCall]);
 
+  // Ensure on-chain balances and info stay current
+  useEffect(() => {
+    if (account) {
+      refreshContractData();
+    }
+  }, [account, refreshContractData]);
+
   // Load current price data
   useEffect(() => {
     if (!contract) return;


### PR DESCRIPTION
## Summary
- Update HeroSection to call `refreshContractData` when a wallet account is present so balances and sale info stay current

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a78484ee4c832295d2088da5b6f551